### PR TITLE
feat: implement spot create/update/soft-delete endpoints (UC 2.1-2.3)

### DIFF
--- a/apps/backend/src/common/errors/domain.error.spec.ts
+++ b/apps/backend/src/common/errors/domain.error.spec.ts
@@ -1,6 +1,10 @@
 import { DomainError } from './domain.error';
 import { InvalidBBoxError } from './invalid-bbox.error';
 import { SpotNotFoundOrDeletedError } from './spot-not-found.error';
+import { TooCloseToExistingSpotError } from './too-close-to-existing-spot.error';
+import { InvalidParkingLocationError } from './invalid-parking-location.error';
+import { DuplicateParkingLocationError } from './duplicate-parking-location.error';
+import { ForbiddenError } from './forbidden.error';
 
 describe('Domain Errors', () => {
   describe('InvalidBBoxError', () => {
@@ -44,6 +48,62 @@ describe('Domain Errors', () => {
     it('should have correct name', () => {
       const error = new SpotNotFoundOrDeletedError('uuid-1');
       expect(error.name).toBe('SpotNotFoundOrDeletedError');
+    });
+  });
+
+  describe('TooCloseToExistingSpotError', () => {
+    it('should have statusCode 409', () => {
+      const error = new TooCloseToExistingSpotError();
+      expect(error.statusCode).toBe(409);
+    });
+
+    it('should have conflict message', () => {
+      const error = new TooCloseToExistingSpotError();
+      expect(error.message).toBe(
+        'A dive spot already exists within 1000m of this location',
+      );
+    });
+  });
+
+  describe('InvalidParkingLocationError', () => {
+    it('should have statusCode 400', () => {
+      const error = new InvalidParkingLocationError('too far');
+      expect(error.statusCode).toBe(400);
+    });
+
+    it('should include reason in message', () => {
+      const error = new InvalidParkingLocationError('too far from center');
+      expect(error.message).toBe(
+        'Invalid parking location: too far from center',
+      );
+    });
+  });
+
+  describe('DuplicateParkingLocationError', () => {
+    it('should have statusCode 409', () => {
+      const error = new DuplicateParkingLocationError();
+      expect(error.statusCode).toBe(409);
+    });
+
+    it('should have duplicate message', () => {
+      const error = new DuplicateParkingLocationError();
+      expect(error.message).toBe(
+        'Duplicate parking location: parking entries must be at least 2m apart',
+      );
+    });
+  });
+
+  describe('ForbiddenError', () => {
+    it('should have statusCode 403', () => {
+      const error = new ForbiddenError('not owner');
+      expect(error.statusCode).toBe(403);
+    });
+
+    it('should include reason in message', () => {
+      const error = new ForbiddenError('not owner or moderator/admin');
+      expect(error.message).toBe(
+        'Forbidden: not owner or moderator/admin',
+      );
     });
   });
 });

--- a/apps/backend/src/common/errors/duplicate-parking-location.error.ts
+++ b/apps/backend/src/common/errors/duplicate-parking-location.error.ts
@@ -1,0 +1,9 @@
+import { DomainError } from './domain.error';
+
+export class DuplicateParkingLocationError extends DomainError {
+  readonly statusCode = 409;
+
+  constructor() {
+    super('Duplicate parking location: parking entries must be at least 2m apart');
+  }
+}

--- a/apps/backend/src/common/errors/forbidden.error.ts
+++ b/apps/backend/src/common/errors/forbidden.error.ts
@@ -1,0 +1,9 @@
+import { DomainError } from './domain.error';
+
+export class ForbiddenError extends DomainError {
+  readonly statusCode = 403;
+
+  constructor(reason: string) {
+    super(`Forbidden: ${reason}`);
+  }
+}

--- a/apps/backend/src/common/errors/index.ts
+++ b/apps/backend/src/common/errors/index.ts
@@ -1,3 +1,7 @@
 export { DomainError } from './domain.error';
 export { InvalidBBoxError } from './invalid-bbox.error';
 export { SpotNotFoundOrDeletedError } from './spot-not-found.error';
+export { TooCloseToExistingSpotError } from './too-close-to-existing-spot.error';
+export { InvalidParkingLocationError } from './invalid-parking-location.error';
+export { DuplicateParkingLocationError } from './duplicate-parking-location.error';
+export { ForbiddenError } from './forbidden.error';

--- a/apps/backend/src/common/errors/invalid-parking-location.error.ts
+++ b/apps/backend/src/common/errors/invalid-parking-location.error.ts
@@ -1,0 +1,9 @@
+import { DomainError } from './domain.error';
+
+export class InvalidParkingLocationError extends DomainError {
+  readonly statusCode = 400;
+
+  constructor(reason: string) {
+    super(`Invalid parking location: ${reason}`);
+  }
+}

--- a/apps/backend/src/common/errors/too-close-to-existing-spot.error.ts
+++ b/apps/backend/src/common/errors/too-close-to-existing-spot.error.ts
@@ -1,0 +1,9 @@
+import { DomainError } from './domain.error';
+
+export class TooCloseToExistingSpotError extends DomainError {
+  readonly statusCode = 409;
+
+  constructor() {
+    super('A dive spot already exists within 1000m of this location');
+  }
+}

--- a/apps/backend/src/common/filters/domain-exception.filter.spec.ts
+++ b/apps/backend/src/common/filters/domain-exception.filter.spec.ts
@@ -2,6 +2,10 @@ import { ArgumentsHost } from '@nestjs/common';
 import { DomainExceptionFilter } from './domain-exception.filter';
 import { InvalidBBoxError } from '../errors/invalid-bbox.error';
 import { SpotNotFoundOrDeletedError } from '../errors/spot-not-found.error';
+import { TooCloseToExistingSpotError } from '../errors/too-close-to-existing-spot.error';
+import { InvalidParkingLocationError } from '../errors/invalid-parking-location.error';
+import { DuplicateParkingLocationError } from '../errors/duplicate-parking-location.error';
+import { ForbiddenError } from '../errors/forbidden.error';
 
 describe('DomainExceptionFilter', () => {
   let filter: DomainExceptionFilter;
@@ -45,6 +49,59 @@ describe('DomainExceptionFilter', () => {
       statusCode: 404,
       error: 'SpotNotFoundOrDeletedError',
       message: 'Spot not found or deleted: uuid-1',
+    });
+  });
+
+  it('should return 409 for TooCloseToExistingSpotError', () => {
+    const error = new TooCloseToExistingSpotError();
+
+    filter.catch(error, mockHost);
+
+    expect(mockReply.status).toHaveBeenCalledWith(409);
+    expect(mockReply.send).toHaveBeenCalledWith({
+      statusCode: 409,
+      error: 'TooCloseToExistingSpotError',
+      message: 'A dive spot already exists within 1000m of this location',
+    });
+  });
+
+  it('should return 400 for InvalidParkingLocationError', () => {
+    const error = new InvalidParkingLocationError('too far');
+
+    filter.catch(error, mockHost);
+
+    expect(mockReply.status).toHaveBeenCalledWith(400);
+    expect(mockReply.send).toHaveBeenCalledWith({
+      statusCode: 400,
+      error: 'InvalidParkingLocationError',
+      message: 'Invalid parking location: too far',
+    });
+  });
+
+  it('should return 409 for DuplicateParkingLocationError', () => {
+    const error = new DuplicateParkingLocationError();
+
+    filter.catch(error, mockHost);
+
+    expect(mockReply.status).toHaveBeenCalledWith(409);
+    expect(mockReply.send).toHaveBeenCalledWith({
+      statusCode: 409,
+      error: 'DuplicateParkingLocationError',
+      message:
+        'Duplicate parking location: parking entries must be at least 2m apart',
+    });
+  });
+
+  it('should return 403 for ForbiddenError', () => {
+    const error = new ForbiddenError('not owner');
+
+    filter.catch(error, mockHost);
+
+    expect(mockReply.status).toHaveBeenCalledWith(403);
+    expect(mockReply.send).toHaveBeenCalledWith({
+      statusCode: 403,
+      error: 'ForbiddenError',
+      message: 'Forbidden: not owner',
     });
   });
 });

--- a/apps/backend/src/modules/spots/dto/create-spot.dto.ts
+++ b/apps/backend/src/modules/spots/dto/create-spot.dto.ts
@@ -1,0 +1,50 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
+import { UpsertParkingLocationDto } from './upsert-parking-location.dto';
+
+export class CreateSpotDto {
+  @IsString()
+  @MinLength(1)
+  @MaxLength(80)
+  title!: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  description?: string;
+
+  @Type(() => Number)
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  centerLat!: number;
+
+  @Type(() => Number)
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  centerLon!: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  accessInfo?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(5)
+  @ValidateNested({ each: true })
+  @Type(() => UpsertParkingLocationDto)
+  parkingLocations?: UpsertParkingLocationDto[];
+}

--- a/apps/backend/src/modules/spots/dto/update-spot.dto.ts
+++ b/apps/backend/src/modules/spots/dto/update-spot.dto.ts
@@ -1,0 +1,36 @@
+import { Type } from 'class-transformer';
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsOptional,
+  IsString,
+  MaxLength,
+  MinLength,
+  ValidateNested,
+} from 'class-validator';
+import { UpsertParkingLocationDto } from './upsert-parking-location.dto';
+
+export class UpdateSpotDto {
+  @IsOptional()
+  @IsString()
+  @MinLength(1)
+  @MaxLength(80)
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  description?: string;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(1000)
+  accessInfo?: string;
+
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(5)
+  @ValidateNested({ each: true })
+  @Type(() => UpsertParkingLocationDto)
+  parkingLocations?: UpsertParkingLocationDto[];
+}

--- a/apps/backend/src/modules/spots/dto/upsert-parking-location.dto.ts
+++ b/apps/backend/src/modules/spots/dto/upsert-parking-location.dto.ts
@@ -1,0 +1,21 @@
+import { Type } from 'class-transformer';
+import { IsNumber, IsOptional, IsString, Max, MaxLength, Min } from 'class-validator';
+
+export class UpsertParkingLocationDto {
+  @Type(() => Number)
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  lat!: number;
+
+  @Type(() => Number)
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  lon!: number;
+
+  @IsOptional()
+  @IsString()
+  @MaxLength(100)
+  label?: string;
+}

--- a/apps/backend/src/modules/spots/spots.controller.spec.ts
+++ b/apps/backend/src/modules/spots/spots.controller.spec.ts
@@ -3,11 +3,17 @@ import { SpotsController } from './spots.controller';
 import { SpotsService } from './spots.service';
 import { UsersService } from '../users/users.service';
 import { JwtVerifyService } from '../../common/auth/jwt-verify.service';
-import { AuthGuard } from '../../common/auth';
+import { AuthGuard, type AuthenticatedUser } from '../../common/auth';
 
 describe('SpotsController', () => {
   let controller: SpotsController;
   let spotsService: jest.Mocked<SpotsService>;
+
+  const mockUser: AuthenticatedUser = {
+    userId: 'uuid-user-1',
+    externalId: 'ext-1',
+    role: 'user',
+  };
 
   const mockListResponse = {
     items: [{ id: 'uuid-1', title: 'Spot', centerLat: 60, centerLon: 5 }],
@@ -40,6 +46,9 @@ describe('SpotsController', () => {
           useValue: {
             listByBBox: jest.fn(),
             getById: jest.fn(),
+            create: jest.fn(),
+            update: jest.fn(),
+            softDelete: jest.fn(),
           },
         },
         {
@@ -97,6 +106,48 @@ describe('SpotsController', () => {
 
       expect(spotsService.getById).toHaveBeenCalledWith('uuid-1');
       expect(result).toEqual(mockDetailResponse);
+    });
+  });
+
+  describe('create', () => {
+    it('should call service with dto and current user', async () => {
+      spotsService.create.mockResolvedValue(mockDetailResponse);
+
+      const dto = {
+        title: 'Spot',
+        centerLat: 60,
+        centerLon: 5,
+      };
+
+      const result = await controller.create(dto, mockUser);
+
+      expect(spotsService.create).toHaveBeenCalledWith(dto, mockUser);
+      expect(result).toEqual(mockDetailResponse);
+    });
+  });
+
+  describe('update', () => {
+    it('should call service with id, dto and current user', async () => {
+      spotsService.update.mockResolvedValue(mockDetailResponse);
+
+      const dto = {
+        title: 'Updated spot',
+      };
+
+      const result = await controller.update('uuid-1', dto, mockUser);
+
+      expect(spotsService.update).toHaveBeenCalledWith('uuid-1', dto, mockUser);
+      expect(result).toEqual(mockDetailResponse);
+    });
+  });
+
+  describe('softDelete', () => {
+    it('should call service with id and current user', async () => {
+      spotsService.softDelete.mockResolvedValue(undefined);
+
+      await controller.softDelete('uuid-1', mockUser);
+
+      expect(spotsService.softDelete).toHaveBeenCalledWith('uuid-1', mockUser);
     });
   });
 });

--- a/apps/backend/src/modules/spots/spots.controller.ts
+++ b/apps/backend/src/modules/spots/spots.controller.ts
@@ -1,16 +1,25 @@
 import {
+  Body,
   Controller,
+  Delete,
   Get,
+  HttpCode,
+  HttpStatus,
   Param,
   ParseUUIDPipe,
+  Patch,
+  Post,
   Query,
   UseGuards,
 } from '@nestjs/common';
-import { AuthGuard } from '../../common/auth';
+import { AuthGuard, CurrentUser } from '../../common/auth';
 import { SpotsService } from './spots.service';
 import { ListSpotsByBBoxQueryDto } from './dto/list-spots-by-bbox-query.dto';
 import { ListSpotsResponseDto } from './dto/list-spots-response.dto';
 import { SpotDetailResponseDto } from './dto/spot-detail-response.dto';
+import { CreateSpotDto } from './dto/create-spot.dto';
+import { UpdateSpotDto } from './dto/update-spot.dto';
+import type { AuthenticatedUser } from '../../common/auth';
 
 @Controller('spots')
 @UseGuards(AuthGuard)
@@ -35,5 +44,31 @@ export class SpotsController {
     @Param('id', new ParseUUIDPipe()) id: string,
   ): Promise<SpotDetailResponseDto> {
     return this.spotsService.getById(id);
+  }
+
+  @Post()
+  async create(
+    @Body() dto: CreateSpotDto,
+    @CurrentUser() actor: AuthenticatedUser,
+  ): Promise<SpotDetailResponseDto> {
+    return this.spotsService.create(dto, actor);
+  }
+
+  @Patch(':id')
+  async update(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @Body() dto: UpdateSpotDto,
+    @CurrentUser() actor: AuthenticatedUser,
+  ): Promise<SpotDetailResponseDto> {
+    return this.spotsService.update(id, dto, actor);
+  }
+
+  @Delete(':id')
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async softDelete(
+    @Param('id', new ParseUUIDPipe()) id: string,
+    @CurrentUser() actor: AuthenticatedUser,
+  ): Promise<void> {
+    await this.spotsService.softDelete(id, actor);
   }
 }

--- a/apps/backend/src/modules/spots/spots.repository.spec.ts
+++ b/apps/backend/src/modules/spots/spots.repository.spec.ts
@@ -4,14 +4,40 @@ import { SpotsRepository } from './spots.repository';
 
 describe('SpotsRepository', () => {
   let repository: SpotsRepository;
-  let prisma: { diveSpot: Record<string, jest.Mock> };
+  let prisma: {
+    diveSpot: Record<string, jest.Mock>;
+    parkingLocation: Record<string, jest.Mock>;
+    $queryRaw: jest.Mock;
+    $transaction: jest.Mock;
+  };
 
   beforeEach(async () => {
+    const tx = {
+      diveSpot: {
+        create: jest.fn(),
+        update: jest.fn(),
+        findFirst: jest.fn(),
+      },
+      parkingLocation: {
+        createMany: jest.fn(),
+        deleteMany: jest.fn(),
+      },
+    };
+
     prisma = {
       diveSpot: {
         findMany: jest.fn(),
         findFirst: jest.fn(),
+        updateMany: jest.fn(),
       },
+      parkingLocation: {
+        createMany: jest.fn(),
+        deleteMany: jest.fn(),
+      },
+      $queryRaw: jest.fn(),
+      $transaction: jest.fn(async (callback: (trx: typeof tx) => unknown) =>
+        callback(tx),
+      ),
     };
 
     const module: TestingModule = await Test.createTestingModule({
@@ -97,6 +123,167 @@ describe('SpotsRepository', () => {
       const result = await repository.findById('nonexistent');
 
       expect(result).toBeNull();
+    });
+  });
+
+  describe('findByIdAnyState', () => {
+    it('should query by id without isDeleted filter', async () => {
+      prisma.diveSpot.findFirst.mockResolvedValue(null);
+
+      await repository.findByIdAnyState('uuid-1');
+
+      expect(prisma.diveSpot.findFirst).toHaveBeenCalledWith({
+        where: { id: 'uuid-1' },
+        include: {
+          parkingLocations: true,
+          createdBy: { select: { displayName: true } },
+        },
+      });
+    });
+  });
+
+  describe('findNearbyCenters', () => {
+    it('should execute raw query and return nearby centers', async () => {
+      const mockRows = [{ id: 'uuid-1', distanceMeters: 230 }];
+      prisma.$queryRaw.mockResolvedValue(mockRows);
+
+      const result = await repository.findNearbyCenters(60, 5, 1000);
+
+      expect(prisma.$queryRaw).toHaveBeenCalled();
+      expect(result).toEqual(mockRows);
+    });
+  });
+
+  describe('createSpot', () => {
+    it('should create spot and parking locations in one transaction', async () => {
+      const txDiveSpot = {
+        create: jest.fn().mockResolvedValue({ id: 'uuid-1' }),
+        update: jest.fn(),
+        findFirst: jest.fn().mockResolvedValue({ id: 'uuid-1' }),
+      };
+      const txParking = {
+        createMany: jest.fn().mockResolvedValue({ count: 1 }),
+        deleteMany: jest.fn(),
+      };
+
+      prisma.$transaction.mockImplementation(
+        async (
+          callback: (trx: {
+            diveSpot: typeof txDiveSpot;
+            parkingLocation: typeof txParking;
+          }) => unknown,
+        ) => callback({ diveSpot: txDiveSpot, parkingLocation: txParking }),
+      );
+
+      const result = await repository.createSpot(
+        {
+          title: 'Spot',
+          description: 'Desc',
+          centerLat: 60,
+          centerLon: 5,
+          createdById: 'user-1',
+          accessInfo: null,
+        },
+        [{ lat: 60.1, lon: 5.1, label: 'Main' }],
+      );
+
+      expect(txDiveSpot.create).toHaveBeenCalledWith({
+        data: {
+          title: 'Spot',
+          description: 'Desc',
+          centerLat: 60,
+          centerLon: 5,
+          createdById: 'user-1',
+          accessInfo: null,
+        },
+      });
+      expect(txParking.createMany).toHaveBeenCalledWith({
+        data: [{ lat: 60.1, lon: 5.1, label: 'Main', spotId: 'uuid-1' }],
+      });
+      expect(result).toEqual({ id: 'uuid-1' });
+    });
+  });
+
+  describe('updateSpot', () => {
+    it('should update spot and replace parking locations when provided', async () => {
+      const txDiveSpot = {
+        create: jest.fn(),
+        update: jest.fn().mockResolvedValue({ id: 'uuid-1' }),
+        findFirst: jest.fn().mockResolvedValue({ id: 'uuid-1' }),
+      };
+      const txParking = {
+        createMany: jest.fn().mockResolvedValue({ count: 2 }),
+        deleteMany: jest.fn().mockResolvedValue({ count: 2 }),
+      };
+
+      prisma.$transaction.mockImplementation(
+        async (
+          callback: (trx: {
+            diveSpot: typeof txDiveSpot;
+            parkingLocation: typeof txParking;
+          }) => unknown,
+        ) => callback({ diveSpot: txDiveSpot, parkingLocation: txParking }),
+      );
+
+      await repository.updateSpot(
+        'uuid-1',
+        { title: 'Updated' },
+        [{ lat: 60.2, lon: 5.2, label: null }],
+      );
+
+      expect(txDiveSpot.update).toHaveBeenCalledWith({
+        where: { id: 'uuid-1' },
+        data: { title: 'Updated' },
+      });
+      expect(txParking.deleteMany).toHaveBeenCalledWith({
+        where: { spotId: 'uuid-1' },
+      });
+      expect(txParking.createMany).toHaveBeenCalledWith({
+        data: [{ lat: 60.2, lon: 5.2, label: null, spotId: 'uuid-1' }],
+      });
+    });
+
+    it('should update only spot fields when parking is omitted', async () => {
+      const txDiveSpot = {
+        create: jest.fn(),
+        update: jest.fn().mockResolvedValue({ id: 'uuid-1' }),
+        findFirst: jest.fn().mockResolvedValue({ id: 'uuid-1' }),
+      };
+      const txParking = {
+        createMany: jest.fn(),
+        deleteMany: jest.fn(),
+      };
+
+      prisma.$transaction.mockImplementation(
+        async (
+          callback: (trx: {
+            diveSpot: typeof txDiveSpot;
+            parkingLocation: typeof txParking;
+          }) => unknown,
+        ) => callback({ diveSpot: txDiveSpot, parkingLocation: txParking }),
+      );
+
+      await repository.updateSpot('uuid-1', { description: 'Updated' });
+
+      expect(txDiveSpot.update).toHaveBeenCalledWith({
+        where: { id: 'uuid-1' },
+        data: { description: 'Updated' },
+      });
+      expect(txParking.deleteMany).not.toHaveBeenCalled();
+      expect(txParking.createMany).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('softDeleteSpot', () => {
+    it('should update only non-deleted spots and set deletedAt', async () => {
+      prisma.diveSpot.updateMany.mockResolvedValue({ count: 1 });
+
+      await repository.softDeleteSpot('uuid-1');
+
+      expect(prisma.diveSpot.updateMany).toHaveBeenCalledWith({
+        where: { id: 'uuid-1', isDeleted: false },
+        data: { isDeleted: true, deletedAt: expect.any(Date) },
+      });
     });
   });
 });

--- a/apps/backend/src/modules/spots/spots.repository.ts
+++ b/apps/backend/src/modules/spots/spots.repository.ts
@@ -1,4 +1,5 @@
 import { Injectable } from '@nestjs/common';
+import { Prisma } from '@prisma/client';
 import { PrismaService } from '../../prisma/prisma.service';
 
 const SPOT_SUMMARY_SELECT = {
@@ -39,6 +40,107 @@ export class SpotsRepository {
     return this.prisma.diveSpot.findFirst({
       where: { id, isDeleted: false },
       include: SPOT_DETAIL_INCLUDE,
+    });
+  }
+
+  async findByIdAnyState(id: string) {
+    return this.prisma.diveSpot.findFirst({
+      where: { id },
+      include: SPOT_DETAIL_INCLUDE,
+    });
+  }
+
+  async findNearbyCenters(lat: number, lon: number, radiusMeters: number) {
+    return this.prisma.$queryRaw<Array<{ id: string; distanceMeters: number }>>(
+      Prisma.sql`
+        SELECT
+          id::text AS id,
+          ST_Distance(
+            ST_SetSRID(ST_MakePoint(center_lon, center_lat), 4326)::geography,
+            ST_SetSRID(ST_MakePoint(${lon}, ${lat}), 4326)::geography
+          ) AS "distanceMeters"
+        FROM dive_spots
+        WHERE is_deleted = false
+          AND ST_DWithin(
+            ST_SetSRID(ST_MakePoint(center_lon, center_lat), 4326)::geography,
+            ST_SetSRID(ST_MakePoint(${lon}, ${lat}), 4326)::geography,
+            ${radiusMeters}
+          )
+        ORDER BY "distanceMeters" ASC
+      `,
+    );
+  }
+
+  async createSpot(
+    data: {
+      title: string;
+      description: string;
+      centerLat: number;
+      centerLon: number;
+      createdById: string;
+      accessInfo: string | null;
+    },
+    parkingLocations: Array<{ lat: number; lon: number; label: string | null }>,
+  ) {
+    return this.prisma.$transaction(async (tx) => {
+      const spot = await tx.diveSpot.create({ data });
+
+      if (parkingLocations.length > 0) {
+        await tx.parkingLocation.createMany({
+          data: parkingLocations.map((parking) => ({
+            lat: parking.lat,
+            lon: parking.lon,
+            label: parking.label,
+            spotId: spot.id,
+          })),
+        });
+      }
+
+      return tx.diveSpot.findFirst({
+        where: { id: spot.id, isDeleted: false },
+        include: SPOT_DETAIL_INCLUDE,
+      });
+    });
+  }
+
+  async updateSpot(
+    id: string,
+    data: {
+      title?: string;
+      description?: string;
+      accessInfo?: string | null;
+    },
+    parkingLocations?: Array<{ lat: number; lon: number; label: string | null }>,
+  ) {
+    return this.prisma.$transaction(async (tx) => {
+      await tx.diveSpot.update({ where: { id }, data });
+
+      if (parkingLocations) {
+        await tx.parkingLocation.deleteMany({ where: { spotId: id } });
+
+        if (parkingLocations.length > 0) {
+          await tx.parkingLocation.createMany({
+            data: parkingLocations.map((parking) => ({
+              lat: parking.lat,
+              lon: parking.lon,
+              label: parking.label,
+              spotId: id,
+            })),
+          });
+        }
+      }
+
+      return tx.diveSpot.findFirst({
+        where: { id, isDeleted: false },
+        include: SPOT_DETAIL_INCLUDE,
+      });
+    });
+  }
+
+  async softDeleteSpot(id: string): Promise<void> {
+    await this.prisma.diveSpot.updateMany({
+      where: { id, isDeleted: false },
+      data: { isDeleted: true, deletedAt: new Date() },
     });
   }
 }

--- a/apps/backend/src/modules/spots/spots.service.spec.ts
+++ b/apps/backend/src/modules/spots/spots.service.spec.ts
@@ -1,14 +1,28 @@
 import { Test, TestingModule } from '@nestjs/testing';
+import { plainToInstance } from 'class-transformer';
+import { validateSync } from 'class-validator';
 import { SpotsService } from './spots.service';
 import { SpotsRepository } from './spots.repository';
 import {
+  DuplicateParkingLocationError,
+  ForbiddenError,
   InvalidBBoxError,
+  InvalidParkingLocationError,
   SpotNotFoundOrDeletedError,
+  TooCloseToExistingSpotError,
 } from '../../common/errors';
+import type { AuthenticatedUser } from '../../common/auth';
+import { UpdateSpotDto } from './dto/update-spot.dto';
 
 describe('SpotsService', () => {
   let service: SpotsService;
   let repository: jest.Mocked<SpotsRepository>;
+
+  const actor: AuthenticatedUser = {
+    userId: 'uuid-user-1',
+    externalId: 'ext-1',
+    role: 'user',
+  };
 
   const mockSpotDetail = {
     id: 'uuid-spot-1',
@@ -45,6 +59,11 @@ describe('SpotsService', () => {
           useValue: {
             listByBBox: jest.fn(),
             findById: jest.fn(),
+            findByIdAnyState: jest.fn(),
+            findNearbyCenters: jest.fn(),
+            createSpot: jest.fn(),
+            updateSpot: jest.fn(),
+            softDeleteSpot: jest.fn(),
           },
         },
       ],
@@ -165,6 +184,240 @@ describe('SpotsService', () => {
       await expect(service.getById('nonexistent')).rejects.toThrow(
         SpotNotFoundOrDeletedError,
       );
+    });
+  });
+
+  describe('create', () => {
+    it('should create spot when nearby check passes and parking is valid', async () => {
+      repository.findNearbyCenters.mockResolvedValue([]);
+      repository.createSpot.mockResolvedValue(mockSpotDetail);
+
+      const dto = {
+        title: 'Spot',
+        description: 'Desc',
+        centerLat: 60,
+        centerLon: 5,
+        accessInfo: 'Access',
+        parkingLocations: [
+          { lat: 60.001, lon: 5.001, label: 'Parking A' },
+          { lat: 60.002, lon: 5.002, label: 'Parking B' },
+        ],
+      };
+
+      const result = await service.create(dto, actor);
+
+      expect(repository.findNearbyCenters).toHaveBeenCalledWith(60, 5, 1000);
+      expect(repository.createSpot).toHaveBeenCalledWith(
+        {
+          title: 'Spot',
+          description: 'Desc',
+          centerLat: 60,
+          centerLon: 5,
+          createdById: actor.userId,
+          accessInfo: 'Access',
+        },
+        [
+          { lat: 60.001, lon: 5.001, label: 'Parking A' },
+          { lat: 60.002, lon: 5.002, label: 'Parking B' },
+        ],
+      );
+      expect(result.id).toBe('uuid-spot-1');
+    });
+
+    it('should throw TooCloseToExistingSpotError when nearby center exists', async () => {
+      repository.findNearbyCenters.mockResolvedValue([
+        { id: 'uuid-existing', distanceMeters: 450 },
+      ]);
+
+      await expect(
+        service.create(
+          {
+            title: 'Spot',
+            centerLat: 60,
+            centerLon: 5,
+          },
+          actor,
+        ),
+      ).rejects.toThrow(TooCloseToExistingSpotError);
+    });
+
+    it('should fail when parking has more than 5 entries', async () => {
+      await expect(
+        service.create(
+          {
+            title: 'Spot',
+            centerLat: 60,
+            centerLon: 5,
+            parkingLocations: [
+              { lat: 60.001, lon: 5.001 },
+              { lat: 60.002, lon: 5.002 },
+              { lat: 60.003, lon: 5.003 },
+              { lat: 60.004, lon: 5.004 },
+              { lat: 60.005, lon: 5.005 },
+              { lat: 60.006, lon: 5.006 },
+            ],
+          },
+          actor,
+        ),
+      ).rejects.toThrow(InvalidParkingLocationError);
+    });
+
+    it('should fail when parking is farther than 5000m from center', async () => {
+      await expect(
+        service.create(
+          {
+            title: 'Spot',
+            centerLat: 60,
+            centerLon: 5,
+            parkingLocations: [{ lat: 61, lon: 5 }],
+          },
+          actor,
+        ),
+      ).rejects.toThrow(InvalidParkingLocationError);
+    });
+
+    it('should fail when parking locations are closer than 2m', async () => {
+      await expect(
+        service.create(
+          {
+            title: 'Spot',
+            centerLat: 60,
+            centerLon: 5,
+            parkingLocations: [
+              { lat: 60.001, lon: 5.001 },
+              { lat: 60.00100001, lon: 5.00100001 },
+            ],
+          },
+          actor,
+        ),
+      ).rejects.toThrow(DuplicateParkingLocationError);
+    });
+  });
+
+  describe('update', () => {
+    it('should allow owner to update', async () => {
+      repository.findByIdAnyState.mockResolvedValue(mockSpotDetail);
+      repository.updateSpot.mockResolvedValue({
+        ...mockSpotDetail,
+        title: 'Updated Spot',
+      });
+
+      const result = await service.update(
+        'uuid-spot-1',
+        { title: 'Updated Spot' },
+        actor,
+      );
+
+      expect(repository.updateSpot).toHaveBeenCalledWith(
+        'uuid-spot-1',
+        { title: 'Updated Spot' },
+        undefined,
+      );
+      expect(result.title).toBe('Updated Spot');
+    });
+
+    it('should allow moderator/admin to update', async () => {
+      repository.findByIdAnyState.mockResolvedValue({
+        ...mockSpotDetail,
+        createdById: 'other-user',
+      });
+      repository.updateSpot.mockResolvedValue({
+        ...mockSpotDetail,
+        createdById: 'other-user',
+        title: 'Updated by moderator',
+      });
+
+      const moderator: AuthenticatedUser = {
+        userId: 'mod-user',
+        externalId: 'ext-mod',
+        role: 'moderator',
+      };
+
+      const result = await service.update(
+        'uuid-spot-1',
+        { title: 'Updated by moderator' },
+        moderator,
+      );
+
+      expect(result.title).toBe('Updated by moderator');
+    });
+
+    it('should reject update when actor is not owner/moderator/admin', async () => {
+      repository.findByIdAnyState.mockResolvedValue({
+        ...mockSpotDetail,
+        createdById: 'other-user',
+      });
+
+      await expect(
+        service.update('uuid-spot-1', { title: 'Nope' }, actor),
+      ).rejects.toThrow(ForbiddenError);
+    });
+  });
+
+  describe('softDelete', () => {
+    it('should allow owner to soft delete', async () => {
+      repository.findByIdAnyState.mockResolvedValue(mockSpotDetail);
+
+      await service.softDelete('uuid-spot-1', actor);
+
+      expect(repository.softDeleteSpot).toHaveBeenCalledWith('uuid-spot-1');
+    });
+
+    it('should allow moderator/admin to soft delete', async () => {
+      repository.findByIdAnyState.mockResolvedValue({
+        ...mockSpotDetail,
+        createdById: 'other-user',
+      });
+
+      const admin: AuthenticatedUser = {
+        userId: 'admin-user',
+        externalId: 'ext-admin',
+        role: 'admin',
+      };
+
+      await service.softDelete('uuid-spot-1', admin);
+
+      expect(repository.softDeleteSpot).toHaveBeenCalledWith('uuid-spot-1');
+    });
+
+    it('should reject soft delete when actor is not owner/moderator/admin', async () => {
+      repository.findByIdAnyState.mockResolvedValue({
+        ...mockSpotDetail,
+        createdById: 'other-user',
+      });
+
+      await expect(service.softDelete('uuid-spot-1', actor)).rejects.toThrow(
+        ForbiddenError,
+      );
+    });
+
+    it('should be idempotent when spot is already soft deleted', async () => {
+      repository.findByIdAnyState.mockResolvedValue({
+        ...mockSpotDetail,
+        isDeleted: true,
+      });
+
+      await service.softDelete('uuid-spot-1', actor);
+
+      expect(repository.softDeleteSpot).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('UpdateSpotDto validation', () => {
+    it('should reject center field updates through DTO whitelist', () => {
+      const dto = plainToInstance(UpdateSpotDto, {
+        title: 'valid title',
+        centerLat: 60,
+      });
+
+      const errors = validateSync(dto, {
+        whitelist: true,
+        forbidNonWhitelisted: true,
+      });
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0]?.property).toBe('centerLat');
+      expect(errors[0]?.constraints?.whitelistValidation).toBeDefined();
     });
   });
 });

--- a/apps/backend/src/modules/spots/spots.service.ts
+++ b/apps/backend/src/modules/spots/spots.service.ts
@@ -1,14 +1,24 @@
 import { Injectable } from '@nestjs/common';
 import { SpotsRepository } from './spots.repository';
 import {
+  DuplicateParkingLocationError,
+  ForbiddenError,
   InvalidBBoxError,
+  InvalidParkingLocationError,
   SpotNotFoundOrDeletedError,
+  TooCloseToExistingSpotError,
 } from '../../common/errors';
 import { ListSpotsResponseDto } from './dto/list-spots-response.dto';
 import { SpotDetailResponseDto } from './dto/spot-detail-response.dto';
+import type { AuthenticatedUser } from '../../common/auth';
+import type { CreateSpotDto } from './dto/create-spot.dto';
+import type { UpdateSpotDto } from './dto/update-spot.dto';
 
 const DEFAULT_LIMIT = 300;
 const MAX_LIMIT = 1000;
+const MIN_SPOT_DISTANCE_METERS = 1000;
+const MAX_PARKING_DISTANCE_METERS = 5000;
+const MIN_PARKING_SEPARATION_METERS = 2;
 
 @Injectable()
 export class SpotsService {
@@ -50,6 +60,134 @@ export class SpotsService {
       throw new SpotNotFoundOrDeletedError(spotId);
     }
 
+    return this.toSpotDetailResponse(spot);
+  }
+
+  async create(
+    dto: CreateSpotDto,
+    actor: AuthenticatedUser,
+  ): Promise<SpotDetailResponseDto> {
+    this.validateParkingLocations(dto.centerLat, dto.centerLon, dto.parkingLocations);
+
+    const nearby = await this.spotsRepository.findNearbyCenters(
+      dto.centerLat,
+      dto.centerLon,
+      MIN_SPOT_DISTANCE_METERS,
+    );
+
+    if (nearby.length > 0) {
+      throw new TooCloseToExistingSpotError();
+    }
+
+    const created = await this.spotsRepository.createSpot(
+      {
+        title: dto.title,
+        description: dto.description ?? '',
+        centerLat: dto.centerLat,
+        centerLon: dto.centerLon,
+        createdById: actor.userId,
+        accessInfo: dto.accessInfo ?? null,
+      },
+      (dto.parkingLocations ?? []).map((parking) => ({
+        lat: parking.lat,
+        lon: parking.lon,
+        label: parking.label ?? null,
+      })),
+    );
+
+    if (!created) {
+      throw new SpotNotFoundOrDeletedError('created-spot');
+    }
+
+    return this.toSpotDetailResponse(created);
+  }
+
+  async update(
+    spotId: string,
+    dto: UpdateSpotDto,
+    actor: AuthenticatedUser,
+  ): Promise<SpotDetailResponseDto> {
+    const existing = await this.spotsRepository.findByIdAnyState(spotId);
+
+    if (!existing || existing.isDeleted) {
+      throw new SpotNotFoundOrDeletedError(spotId);
+    }
+
+    this.assertCanMutate(existing.createdById, actor);
+
+    this.validateParkingLocations(
+      existing.centerLat,
+      existing.centerLon,
+      dto.parkingLocations,
+    );
+
+    if (
+      dto.title === undefined &&
+      dto.description === undefined &&
+      dto.accessInfo === undefined &&
+      dto.parkingLocations === undefined
+    ) {
+      return this.toSpotDetailResponse(existing);
+    }
+
+    const updated = await this.spotsRepository.updateSpot(
+      spotId,
+      {
+        ...(dto.title !== undefined ? { title: dto.title } : {}),
+        ...(dto.description !== undefined
+          ? { description: dto.description ?? '' }
+          : {}),
+        ...(dto.accessInfo !== undefined
+          ? { accessInfo: dto.accessInfo ?? null }
+          : {}),
+      },
+      dto.parkingLocations
+        ? dto.parkingLocations.map((parking) => ({
+            lat: parking.lat,
+            lon: parking.lon,
+            label: parking.label ?? null,
+          }))
+        : undefined,
+    );
+
+    if (!updated) {
+      throw new SpotNotFoundOrDeletedError(spotId);
+    }
+
+    return this.toSpotDetailResponse(updated);
+  }
+
+  async softDelete(spotId: string, actor: AuthenticatedUser): Promise<void> {
+    const existing = await this.spotsRepository.findByIdAnyState(spotId);
+
+    if (!existing) {
+      throw new SpotNotFoundOrDeletedError(spotId);
+    }
+
+    this.assertCanMutate(existing.createdById, actor);
+
+    if (existing.isDeleted) {
+      return;
+    }
+
+    await this.spotsRepository.softDeleteSpot(spotId);
+  }
+
+  private toSpotDetailResponse(spot: {
+    id: string;
+    title: string;
+    description: string;
+    centerLat: number;
+    centerLon: number;
+    createdById: string;
+    createdBy: { displayName: string | null };
+    accessInfo: string | null;
+    parkingLocations: Array<{ id: string; lat: number; lon: number; label: string | null }>;
+    shareUrl: string | null;
+    shareableAccessInfo: boolean | null;
+    createdAt: Date;
+    updatedAt: Date;
+  }): SpotDetailResponseDto {
     return {
       id: spot.id,
       title: spot.title,
@@ -70,5 +208,91 @@ export class SpotsService {
       createdAt: spot.createdAt,
       updatedAt: spot.updatedAt,
     };
+  }
+
+  private assertCanMutate(createdById: string, actor: AuthenticatedUser): void {
+    const isOwner = createdById === actor.userId;
+    const isPrivileged = ['moderator', 'admin'].includes(actor.role);
+
+    if (!isOwner && !isPrivileged) {
+      throw new ForbiddenError('only owner, moderator, or admin may modify spot');
+    }
+  }
+
+  private validateParkingLocations(
+    centerLat: number,
+    centerLon: number,
+    parkingLocations?: Array<{ lat: number; lon: number }>,
+  ): void {
+    if (!parkingLocations) {
+      return;
+    }
+
+    if (parkingLocations.length > 5) {
+      throw new InvalidParkingLocationError('max 5 parking locations are allowed');
+    }
+
+    for (let i = 0; i < parkingLocations.length; i += 1) {
+      const current = parkingLocations[i];
+      if (!current) {
+        continue;
+      }
+
+      const distanceFromCenter = this.distanceMeters(
+        centerLat,
+        centerLon,
+        current.lat,
+        current.lon,
+      );
+
+      if (distanceFromCenter > MAX_PARKING_DISTANCE_METERS) {
+        throw new InvalidParkingLocationError(
+          'parking location must be within 5000m of spot center',
+        );
+      }
+
+      for (let j = i + 1; j < parkingLocations.length; j += 1) {
+        const other = parkingLocations[j];
+        if (!other) {
+          continue;
+        }
+
+        const distanceBetweenParkings = this.distanceMeters(
+          current.lat,
+          current.lon,
+          other.lat,
+          other.lon,
+        );
+
+        if (distanceBetweenParkings < MIN_PARKING_SEPARATION_METERS) {
+          throw new DuplicateParkingLocationError();
+        }
+      }
+    }
+  }
+
+  private distanceMeters(
+    lat1: number,
+    lon1: number,
+    lat2: number,
+    lon2: number,
+  ): number {
+    const earthRadius = 6371000;
+
+    const lat1Rad = (lat1 * Math.PI) / 180;
+    const lat2Rad = (lat2 * Math.PI) / 180;
+    const deltaLat = ((lat2 - lat1) * Math.PI) / 180;
+    const deltaLon = ((lon2 - lon1) * Math.PI) / 180;
+
+    const a =
+      Math.sin(deltaLat / 2) * Math.sin(deltaLat / 2) +
+      Math.cos(lat1Rad) *
+        Math.cos(lat2Rad) *
+        Math.sin(deltaLon / 2) *
+        Math.sin(deltaLon / 2);
+
+    const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+
+    return earthRadius * c;
   }
 }


### PR DESCRIPTION
## Summary\n- implement POST /spots, PATCH /spots/:id, DELETE /spots/:id (idempotent)\n- enforce proximity + parking domain constraints and owner/moderator/admin authorization\n- add repository transaction flows and PostGIS nearby-center query\n- add/extend controller, service, repository, and error/filter tests\n\n## Details\n- new errors: TooCloseToExistingSpotError, InvalidParkingLocationError, DuplicateParkingLocationError, ForbiddenError\n- new DTOs: CreateSpotDto, UpdateSpotDto, UpsertParkingLocationDto\n- delete returns 204 and is idempotent\n\n## Notes\n- verification in this environment is blocked by missing node_modules and npm registry DNS failure\n\nCloses #12