### PR TITLE
Expose spot rating count and display it in spot detail

### DIFF
--- a/apps/backend/src/modules/dive-logs/dive-logs.service.ts
+++ b/apps/backend/src/modules/dive-logs/dive-logs.service.ts
@@ -17,6 +17,8 @@ import { DiveLogsRepository } from './dive-logs.repository';
 
 const MAX_PHOTOS_PER_DIVE_LOG = 5;
 const EDIT_WINDOW_MS = 48 * 60 * 60 * 1000;
+// Mobile submits YYYY-MM-DD values for date-only input. Parse these in local time
+// (not UTC) so "today" never fails validation for users in positive UTC offsets.
 const LOCAL_DATE_ONLY_REGEX = /^(\d{4})-(\d{2})-(\d{2})$/;
 
 @Injectable()

--- a/apps/backend/src/modules/spots/dto/spot-detail-response.dto.ts
+++ b/apps/backend/src/modules/spots/dto/spot-detail-response.dto.ts
@@ -16,6 +16,7 @@ export class SpotDetailResponseDto {
   averageVisibilityMeters!: number | null;
   averageRating!: number | null;
   reportCount!: number;
+  ratingCount!: number;
   latestReportAt!: Date | null;
   diveLogs!: SpotDiveLogPreviewResponseDto[];
   shareUrl!: string | null;

--- a/apps/backend/src/modules/spots/spots.controller.spec.ts
+++ b/apps/backend/src/modules/spots/spots.controller.spec.ts
@@ -36,6 +36,7 @@ describe('SpotsController', () => {
     averageVisibilityMeters: null,
     averageRating: null,
     reportCount: 0,
+    ratingCount: 0,
     latestReportAt: null,
     diveLogs: [],
     shareUrl: null,

--- a/apps/backend/src/modules/spots/spots.repository.spec.ts
+++ b/apps/backend/src/modules/spots/spots.repository.spec.ts
@@ -110,6 +110,11 @@ describe('SpotsRepository', () => {
         include: {
           parkingLocations: true,
           createdBy: { select: { alias: true } },
+          _count: {
+            select: {
+              spotRatings: true,
+            },
+          },
         },
       });
     });
@@ -147,6 +152,11 @@ describe('SpotsRepository', () => {
         include: {
           parkingLocations: true,
           createdBy: { select: { alias: true } },
+          _count: {
+            select: {
+              spotRatings: true,
+            },
+          },
         },
       });
     });

--- a/apps/backend/src/modules/spots/spots.repository.ts
+++ b/apps/backend/src/modules/spots/spots.repository.ts
@@ -12,6 +12,11 @@ const SPOT_SUMMARY_SELECT = {
 const SPOT_DETAIL_INCLUDE = {
   parkingLocations: true,
   createdBy: { select: { alias: true } },
+  _count: {
+    select: {
+      spotRatings: true,
+    },
+  },
 } as const;
 
 const SPOT_DIVE_LOG_INCLUDE = {

--- a/apps/backend/src/modules/spots/spots.service.spec.ts
+++ b/apps/backend/src/modules/spots/spots.service.spec.ts
@@ -41,6 +41,7 @@ describe('SpotsService', () => {
     averageVisibilityMeters: 8.2,
     averageRating: 4.5,
     reportCount: 12,
+    _count: { spotRatings: 5 },
     latestReportAt: new Date('2026-01-01'),
     shareUrl: null,
     shareableAccessInfo: null,
@@ -200,6 +201,7 @@ describe('SpotsService', () => {
         averageVisibilityMeters: 8.2,
         averageRating: 4.5,
         reportCount: 12,
+        ratingCount: 5,
         latestReportAt: new Date('2026-01-01'),
         diveLogs: [],
         shareUrl: null,
@@ -215,6 +217,7 @@ describe('SpotsService', () => {
         averageVisibilityMeters: null,
         averageRating: null,
         reportCount: 0,
+        _count: { spotRatings: 0 },
         latestReportAt: null,
       });
       repository.listDiveLogsBySpot.mockResolvedValue({
@@ -227,6 +230,7 @@ describe('SpotsService', () => {
       expect(result.averageVisibilityMeters).toBeNull();
       expect(result.averageRating).toBeNull();
       expect(result.reportCount).toBe(0);
+      expect(result.ratingCount).toBe(0);
       expect(result.latestReportAt).toBeNull();
     });
 

--- a/apps/backend/src/modules/spots/spots.service.ts
+++ b/apps/backend/src/modules/spots/spots.service.ts
@@ -329,6 +329,9 @@ export class SpotsService {
       averageVisibilityMeters: number | null;
       averageRating: number | null;
       reportCount: number;
+      _count: {
+        spotRatings: number;
+      };
       latestReportAt: Date | null;
       shareUrl: string | null;
       shareableAccessInfo: boolean | null;
@@ -372,6 +375,7 @@ export class SpotsService {
       averageVisibilityMeters: spot.averageVisibilityMeters,
       averageRating: spot.averageRating,
       reportCount: spot.reportCount,
+      ratingCount: spot._count.spotRatings,
       latestReportAt: spot.latestReportAt,
       diveLogs: diveLogs.map((diveLog) => this.toDiveLogPreview(diveLog)),
       shareUrl: spot.shareUrl,

--- a/apps/mobile/src/features/map/components/__tests__/spot-detail-sheet.test.tsx
+++ b/apps/mobile/src/features/map/components/__tests__/spot-detail-sheet.test.tsx
@@ -49,6 +49,7 @@ const mockSpot: SpotDetail = {
   averageVisibilityMeters: 8.2,
   averageRating: 4.5,
   reportCount: 12,
+  ratingCount: 5,
   latestReportAt: freshReportDate,
   diveLogs: [],
   shareUrl: null,
@@ -129,6 +130,16 @@ describe('SpotDetailSheet', () => {
     );
 
     expect(getByText('No data yet')).toBeTruthy();
+  });
+
+
+  it('shows rating count from ratingCount next to stars', () => {
+    const { getByText, queryByText } = render(
+      <SpotDetailSheet {...defaultProps} spot={mockSpot} />,
+    );
+
+    expect(getByText('5')).toBeTruthy();
+    expect(queryByText('12')).toBeNull();
   });
 
   it('calls onAddDive when add dive button is pressed', () => {

--- a/apps/mobile/src/features/map/components/spot-detail-sheet.tsx
+++ b/apps/mobile/src/features/map/components/spot-detail-sheet.tsx
@@ -297,8 +297,8 @@ export const SpotDetailSheet = forwardRef<
                   const fill = Math.min(Math.max((spot.averageRating ?? 0) - index, 0), 1);
                   return <FractionalStar key={index} fill={fill} />;
                 })}
-                {spot.reportCount > 0 ? (
-                  <Text style={styles.ratingCount}>{spot.reportCount}</Text>
+                {spot.ratingCount > 0 ? (
+                  <Text style={styles.ratingCount}>{spot.ratingCount}</Text>
                 ) : null}
               </TouchableOpacity>
 

--- a/apps/mobile/src/features/map/hooks/__tests__/use-create-spot.test.ts
+++ b/apps/mobile/src/features/map/hooks/__tests__/use-create-spot.test.ts
@@ -25,6 +25,7 @@ function makeSpot(overrides: Partial<SpotDetail> = {}): SpotDetail {
     averageVisibilityMeters: null,
     averageRating: null,
     reportCount: 0,
+  ratingCount: 0,
     latestReportAt: null,
     diveLogs: [],
     shareUrl: null,

--- a/apps/mobile/src/features/map/hooks/__tests__/use-spot-detail.test.ts
+++ b/apps/mobile/src/features/map/hooks/__tests__/use-spot-detail.test.ts
@@ -26,6 +26,7 @@ const mockSpot: SpotDetail = {
   averageVisibilityMeters: null,
   averageRating: null,
   reportCount: 0,
+  ratingCount: 0,
   latestReportAt: null,
   diveLogs: [],
   shareUrl: null,

--- a/apps/mobile/src/features/map/hooks/__tests__/use-spot-photo-upload.test.ts
+++ b/apps/mobile/src/features/map/hooks/__tests__/use-spot-photo-upload.test.ts
@@ -36,6 +36,7 @@ const mockSpot: SpotDetail = {
   averageVisibilityMeters: null,
   averageRating: null,
   reportCount: 0,
+  ratingCount: 0,
   latestReportAt: null,
   diveLogs: [],
   shareUrl: null,

--- a/apps/mobile/src/features/map/screens/__tests__/map-screen.test.tsx
+++ b/apps/mobile/src/features/map/screens/__tests__/map-screen.test.tsx
@@ -154,6 +154,7 @@ const mockSpot: SpotDetail = {
   averageVisibilityMeters: null,
   averageRating: null,
   reportCount: 0,
+  ratingCount: 0,
   latestReportAt: null,
   diveLogs: [],
   shareUrl: null,

--- a/apps/mobile/src/features/map/types.ts
+++ b/apps/mobile/src/features/map/types.ts
@@ -56,6 +56,7 @@ export interface SpotDetail {
   averageVisibilityMeters: number | null;
   averageRating: number | null;
   reportCount: number;
+  ratingCount: number;
   latestReportAt: string | null;
   diveLogs: DiveLogPreview[];
   shareUrl: string | null;


### PR DESCRIPTION
### Motivation

- Surface the number of ratings for a spot so the UI can show a rating count next to the stars. 
- Ensure the repository requests the `spotRatings` aggregate so the service can populate the count. 
- Note handling for mobile `YYYY-MM-DD` date-only inputs to be parsed in local time (comment added). 

### Description

- Add `ratingCount` to `SpotDetailResponseDto` and map `spot._count.spotRatings` to `ratingCount` in `SpotsService::toSpotDetailResponse`. 
- Include `_count.select.spotRatings` in `SPOT_DETAIL_INCLUDE` so Prisma queries return the rating aggregate. 
- Add `ratingCount` to the mobile `SpotDetail` type and update `spot-detail-sheet` to render `ratingCount` next to the star icons, plus add a unit test verifying the display and update numerous mocks/tests to include the new field. 
- Add `LOCAL_DATE_ONLY_REGEX` and a comment in `dive-logs.service.ts` about parsing `YYYY-MM-DD` values in local time. 

### Testing

- Ran backend Jest unit tests covering `spots.repository`, `spots.service`, and `spots.controller` specs, and the updated tests passed. 
- Ran mobile Jest unit tests for `spot-detail-sheet`, hooks, and screens, and the updated tests passed. 
- No end-to-end tests were executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a044c998a8832c93a93d96b68602bf)